### PR TITLE
Use maintained uuid package, add dep support and helper methods

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,38 @@
+# Gopkg.toml example
+#
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
+# for detailed Gopkg.toml documentation.
+#
+# required = ["github.com/user/thing/cmd/thing"]
+# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
+#
+# [[constraint]]
+#   name = "github.com/user/project"
+#   version = "1.0.0"
+#
+# [[constraint]]
+#   name = "github.com/user/project2"
+#   branch = "dev"
+#   source = "github.com/myfork/project2"
+#
+# [[override]]
+#   name = "github.com/x/y"
+#   version = "2.4.0"
+#
+# [prune]
+#   non-go = false
+#   go-tests = true
+#   unused-packages = true
+
+
+[[constraint]]
+  name = "github.com/gin-gonic/gin"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/gofrs/uuid"
+  version = "3.1.2"
+
+[prune]
+  go-tests = true
+  unused-packages = true


### PR DESCRIPTION
- Use fork of satori uuid with various fixes: https://github.com/gofrs/uuid#project-history
- Add dep support to make it easier for projects that add this as a dependency.
- Change Middleware name and add helper method for returning the request ID given a gin context.
- Normalize header string and put it inside an exported constant.
- Normalize context key string and put it inside an exporter constant.
- Support settings a flag that makes the package panic if there was an error generating the uuid.